### PR TITLE
Add jane automapper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,16 @@
 		}
 	],
 	"require": {
-		"symfony/console": "~2.3",
-		"symfony/finder": "~2.3",
-		"symfony/stopwatch": "~2.3",
+		"symfony/console": "^4.0",
+		"symfony/finder": "^4.0",
+		"symfony/stopwatch": "^4.0",
 		"idr0id/papper": "dev-master",
 		"bcc/auto-mapper-bundle": "dev-master",
 		"nylle/php-automapper": "dev-master",
-        "trismegiste/alkahest": "dev-master",
-        "mark-gerarts/auto-mapper-plus": "@dev"
+		"trismegiste/alkahest": "dev-master",
+		"jane-php/automapper": "dev-master",
+		"mark-gerarts/auto-mapper-plus": "@dev",
+		"phpdocumentor/reflection-docblock": "^4.3"
 	},
 	"autoload": {
 		"psr-0": {

--- a/src/Benchmap/Console/Command/BenchmapCommand.php
+++ b/src/Benchmap/Console/Command/BenchmapCommand.php
@@ -5,6 +5,7 @@ namespace Benchmap\Console\Command;
 use Benchmap\Result;
 use Benchmap\Runner;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -51,10 +52,9 @@ class BenchmapCommand extends Command
 			return array($result->getName(), $result->getDuration(), $result->getMemory());
 		}, $results);
 
-		/* @var \Symfony\Component\Console\Helper\TableHelper $table */
-		$table = $this->getHelper('table');
+		$table = new Table($output);
 		$table->setHeaders(array('package', 'duration (MS)', 'MEM (B)'));
 		$table->addRows($rows);
-		$table->render($output);
+		$table->render();
 	}
 }

--- a/src/Benchmap/Task/JaneAutoMapperOptimizedTask.php
+++ b/src/Benchmap/Task/JaneAutoMapperOptimizedTask.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Benchmap\Task;
+
+use Benchmap\Domain\User;
+use Benchmap\Domain\UserDTO;
+use Benchmap\TaskInterface;
+use Jane\AutoMapper\Compiler\Accessor;
+use Jane\AutoMapper\Compiler\Compiler;
+use Jane\AutoMapper\Compiler\Transformer\TransformerFactory;
+use Jane\AutoMapper\MapperConfiguration;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+
+class JaneAutoMapperOptimizedTask implements TaskInterface
+{
+    private $compiler;
+
+    private $mapper;
+
+    public function __construct()
+    {
+        $this->compiler = new Compiler(new PropertyInfoExtractor(
+            [new ReflectionExtractor()],
+            [new ReflectionExtractor(), new PhpDocExtractor()],
+            [new ReflectionExtractor()],
+            [new ReflectionExtractor()]
+        ), new Accessor(), new TransformerFactory());
+
+        // We assume that we get the mapper directly and that it has been previously writed to disk (so compile time is not included here)
+        $configurationUser = new MapperConfiguration($this->compiler, User::class, UserDTO::class);
+        $this->mapper = $configurationUser->getMapper();
+    }
+
+    public function getName()
+    {
+        return 'jane-php/automapper (optimized)';
+    }
+
+    public function prepare()
+    {
+    }
+
+    public function run(array $sources)
+    {
+        foreach ($sources as $source) {
+            $this->mapper->map($source);
+        }
+    }
+
+    public function isValid()
+    {
+       return true;
+    }
+}

--- a/src/Benchmap/Task/JaneAutoMapperTask.php
+++ b/src/Benchmap/Task/JaneAutoMapperTask.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Benchmap\Task;
+
+use Benchmap\Domain\User;
+use Benchmap\Domain\UserDTO;
+use Benchmap\TaskInterface;
+use Jane\AutoMapper\AutoMapper;
+use Jane\AutoMapper\Compiler\Accessor;
+use Jane\AutoMapper\Compiler\Compiler;
+use Jane\AutoMapper\Compiler\Transformer\TransformerFactory;
+use Jane\AutoMapper\MapperConfiguration;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+
+class JaneAutoMapperTask implements TaskInterface
+{
+    private $compiler;
+
+    private $autoMapper;
+
+    public function __construct()
+    {
+        $this->compiler = new Compiler(new PropertyInfoExtractor(
+            [new ReflectionExtractor()],
+            [new ReflectionExtractor(), new PhpDocExtractor()],
+            [new ReflectionExtractor()],
+            [new ReflectionExtractor()]
+        ), new Accessor(), new TransformerFactory());
+        $this->autoMapper = new AutoMapper();
+    }
+
+    public function getName()
+    {
+        return 'jane-php/automapper';
+    }
+
+    public function prepare()
+    {
+        $configurationUser = new MapperConfiguration($this->compiler, User::class, UserDTO::class);
+        $this->autoMapper->register($configurationUser);
+    }
+
+    public function run(array $sources)
+    {
+        foreach ($sources as $source) {
+            $this->autoMapper->map($source, UserDTO::class);
+        }
+    }
+
+    public function isValid()
+    {
+       return true;
+    }
+}


### PR DESCRIPTION
Thanks for this lib.

I'm currently writing an automapper which is built for performance on many objects, i want it as close as possible as native perfs (so in fact it generate native code).

Added here so i can compare with other implementations, it does not offer same feature level as others libs ATM and it is still expiremental but it's a good base IMO.

Two different task where added, one is the optimized version (when the user will compile on production server), other one is the "on-fly" version, which is the default one and which will be used in dev environment.