### PR TITLE
Fix error on Jane AutoMapper optimized task

### DIFF
--- a/src/Benchmap/Task/JaneAutoMapperOptimizedTask.php
+++ b/src/Benchmap/Task/JaneAutoMapperOptimizedTask.php
@@ -10,6 +10,7 @@ use Jane\AutoMapper\Compiler\Accessor;
 use Jane\AutoMapper\Compiler\Compiler;
 use Jane\AutoMapper\Compiler\SourceTargetPropertiesMappingExtractor;
 use Jane\AutoMapper\Compiler\Transformer\TransformerFactory;
+use Jane\AutoMapper\Context;
 use Jane\AutoMapper\MapperConfiguration;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
@@ -45,7 +46,7 @@ class JaneAutoMapperOptimizedTask implements TaskInterface
     public function run(array $sources)
     {
         foreach ($sources as $source) {
-            $this->mapper->map($source);
+            $this->mapper->map($source, new Context());
         }
     }
 


### PR DESCRIPTION
The CI has been failing for [a while](https://travis-ci.org/idr0id/php-mappers-benchmarks/builds) now due to an error in the Jane AutoMapper task. This PR seems to fix the issue, and the object still gets mapped properly. Though, it might be best if @joelwurtz reviewed it.  