### PR TITLE
Fix broken JanePHP tasks

### DIFF
--- a/src/Benchmap/Task/JaneAutoMapperOptimizedTask.php
+++ b/src/Benchmap/Task/JaneAutoMapperOptimizedTask.php
@@ -7,9 +7,12 @@ use Benchmap\Domain\UserDTO;
 use Benchmap\TaskInterface;
 use Jane\AutoMapper\AutoMapper;
 use Jane\AutoMapper\Compiler\Accessor;
-use Jane\AutoMapper\Compiler\Compiler;
 use Jane\AutoMapper\Compiler\SourceTargetPropertiesMappingExtractor;
-use Jane\AutoMapper\Compiler\Transformer\TransformerFactory;
+use Jane\AutoMapper\Compiler\Transformer\ArrayTransformerFactory;
+use Jane\AutoMapper\Compiler\Transformer\BuiltinTransformerFactory;
+use Jane\AutoMapper\Compiler\Transformer\ChainTransformerFactory;
+use Jane\AutoMapper\Compiler\Transformer\MultipleTransformerFactory;
+use Jane\AutoMapper\Compiler\Transformer\ObjectTransformerFactory;
 use Jane\AutoMapper\Context;
 use Jane\AutoMapper\MapperConfiguration;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
@@ -22,12 +25,22 @@ class JaneAutoMapperOptimizedTask implements TaskInterface
 
     public function __construct()
     {
-        $mappingExtractor = new SourceTargetPropertiesMappingExtractor(new PropertyInfoExtractor(
-            [new ReflectionExtractor()],
-            [new ReflectionExtractor(), new PhpDocExtractor()],
-            [new ReflectionExtractor()],
-            [new ReflectionExtractor()]
-        ), new Accessor\ReflectionAccessorExtractor(), new TransformerFactory());
+        $transformerFactory = new ChainTransformerFactory();
+        $transformerFactory->addTransformerFactory(new MultipleTransformerFactory($transformerFactory), 0);
+        $transformerFactory->addTransformerFactory(new BuiltinTransformerFactory(), 1);
+        $transformerFactory->addTransformerFactory(new ArrayTransformerFactory($transformerFactory), 2);
+        $transformerFactory->addTransformerFactory(new ObjectTransformerFactory(), 3);
+
+        $mappingExtractor = new SourceTargetPropertiesMappingExtractor(
+            new PropertyInfoExtractor(
+                [new ReflectionExtractor()],
+                [new ReflectionExtractor(), new PhpDocExtractor()],
+                [new ReflectionExtractor()],
+                [new ReflectionExtractor()]
+            ),
+            new Accessor\ReflectionAccessorExtractor(),
+            $transformerFactory
+        );
         $autoMapper = new AutoMapper();
         // We assume that we get the mapper directly and that it has been previously writed to disk (so compile time is not included here)
         $autoMapper->register(new MapperConfiguration($mappingExtractor, User::class, UserDTO::class));


### PR DESCRIPTION
The builds are failing because of the Jane tasks. Apparently, the `TransformerFactory` has been replaced by specific factories that can be chained.